### PR TITLE
added .Rhistory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Rproj.user
 data/raw_data
 data/processed
+.Rhistory


### PR DESCRIPTION
I have changed the .gitignore file, by adding the .Rhistory file. I added this file to the .gitignore because it stores local command history and this causes errors while pulling in Rstudio.

Fixes #28 